### PR TITLE
Refactor the AnnouncementItem state structure

### DIFF
--- a/bibliotekanarynku9_ui/src/helpers/utils.js
+++ b/bibliotekanarynku9_ui/src/helpers/utils.js
@@ -33,4 +33,4 @@ export const removeBase64Prefix = dataUrlContent => dataUrlContent.split(',').po
 
 export const getTranslation = obj => obj.translations.length > 0 ? obj.translations[0] : {};
 
-export const getLinks = obj => obj.links || [];
+export const getLinks = obj => obj.translations.length > 0 ? obj.translations[0].links : [];


### PR DESCRIPTION
Split all of announcement entity data to the following
state fields: announcement, translation and links