### PR TITLE
Admins UI permission restrict

### DIFF
--- a/bibliotekanarynku9_administration_panel/src/components/adminMessage/AdminMessage.js
+++ b/bibliotekanarynku9_administration_panel/src/components/adminMessage/AdminMessage.js
@@ -4,13 +4,11 @@ import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import Button from '@material-ui/core/Button';
 
-
 const baseStyle = {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center'
 };
-
 
 export default class AdminMessage extends React.Component {
     render() {
@@ -23,7 +21,7 @@ export default class AdminMessage extends React.Component {
                     </CardContent>
                     <CardActions>
                         {
-                            this.props.links.map((link, index) => (
+                            this.props.links && this.props.links.map((link, index) => (
                                 <Button
                                     size='small'
                                     color='primary'

--- a/bibliotekanarynku9_administration_panel/src/containers/Admin/Admin.js
+++ b/bibliotekanarynku9_administration_panel/src/containers/Admin/Admin.js
@@ -4,8 +4,8 @@ import AdminNavigationList from './AdminNavigationList';
 import AdminAccessMessage from './AdminAccessMessage';
 import AdminAppBar from './AdminAppBar';
 import AdminRouter from './AdminRouter';
-import {getManageApps, getLogout} from './adminService';
-import {getUpdatedState, isLogged} from '../../helpers';
+import {getManageApps, getLogout, requestPermissions} from './adminService';
+import {getUpdatedState} from '../../helpers';
 
 class Admin extends React.Component {
 
@@ -18,15 +18,16 @@ class Admin extends React.Component {
     }
 
     componentWillMount() {
-        if (isLogged()) {
-            getManageApps().then(response => {
-                if (response.status === 200) {
-                    this.setState(getUpdatedState({
-                        manageApps: response.data.apps
-                    }, this.state));
-                }
+        requestPermissions().
+            then(() => {
+                getManageApps().then(response => {
+                    if (response.status === 200) {
+                        this.setState(getUpdatedState({
+                            manageApps: response.data.apps
+                        }, this.state));
+                    }
+                });
             });
-        }
     }
 
     navigateToItem = itemName => {
@@ -57,10 +58,6 @@ class Admin extends React.Component {
     renderManageApps = () => {
         return (
             <div>
-                <AdminAppBar
-                    onLogoutClick={this.handleLogoutClick}
-                    onNavIconClick={this.handleNavIconClick}
-                />
                 <AdminNavigationList
                     items={this.state.manageApps}
                     onItemClick={this.navigateToItem}
@@ -80,8 +77,16 @@ class Admin extends React.Component {
     }
 
     render() {
-        const element = isLogged() ? this.renderManageApps() : this.renderAdminMessage();
-        return(element);
+        const element = this.state.manageApps.length ? this.renderManageApps() : this.renderAdminMessage();
+        return (
+            <div>
+                <AdminAppBar
+                    onLogoutClick={this.handleLogoutClick}
+                    onNavIconClick={this.handleNavIconClick}
+                />
+                {element}
+            </div>
+        );
     }
 }
 

--- a/bibliotekanarynku9_administration_panel/src/containers/Admin/AdminAccessMessage.js
+++ b/bibliotekanarynku9_administration_panel/src/containers/Admin/AdminAccessMessage.js
@@ -1,18 +1,16 @@
 import React from 'react';
 import {withRouter} from 'react-router';
 import AdminMessage from  '../../components/adminMessage';
+import {isLogged} from '../../helpers';
 
 const messageBodyStyle = {
     width: '50%'
 };
 
-const adminAccessMessageTxt = 'You are not authenticated. Please navigate to Login view.';
+const adminLoginAccessMessageTxt = 'You are not authenticated. Please navigate to Login view.',
+    adminPermissionsAccessMessageTxt = 'You are not Administrators group member. Please request admin permissions.';
 
 class AdminAccessMessage extends React.Component {
-
-    constructor(props) {
-        super(props);
-    }
 
     navigateToLogin = () => {
         this.props.history.push('/login');
@@ -20,16 +18,32 @@ class AdminAccessMessage extends React.Component {
 
     links = [{text: 'Go to Login', onClick: this.navigateToLogin}];
 
-    render() {
-        return (
+    renderLoginMessage = () => {
+        return(
             <div>
                 <AdminMessage
                     messageBodyStyle={messageBodyStyle}
-                    message={adminAccessMessageTxt}
+                    message={adminLoginAccessMessageTxt}
                     links={this.links}
                 />
             </div>
         );
+    }
+
+    renderPermissionsMessage = () => {
+        return(
+            <div>
+                <AdminMessage
+                    messageBodyStyle={messageBodyStyle}
+                    message={adminPermissionsAccessMessageTxt}
+                />
+            </div>
+        );
+    }
+
+    render() {
+        const message = isLogged() ? this.renderPermissionsMessage() : this.renderLoginMessage();
+        return message;
     }
 }
 

--- a/bibliotekanarynku9_administration_panel/src/containers/Admin/adminService.js
+++ b/bibliotekanarynku9_administration_panel/src/containers/Admin/adminService.js
@@ -12,3 +12,9 @@ export const getLogout = () => {
         url = apiPath + logoutPath;
     return axios.get(url);
 };
+
+export const requestPermissions = () => {
+    const permissionsPath = 'admin/permissions/',
+        url = apiPath + permissionsPath;
+    return axios.get(url);
+};

--- a/bibliotekanarynku9_api/admin/views.py
+++ b/bibliotekanarynku9_api/admin/views.py
@@ -12,9 +12,11 @@ from utils.data_access import get_object_or_none
 from utils.jwt_token import create_token, handle_token
 from utils.responses import (RESPONSE_200_ADMINS_JOINED,
                              RESPONSE_200_ADMINS_REQUESTED,
+                             RESPONSE_200_ADMINS_PERMISSIONS_COMFIRMED,
                              RESPONSE_400_INVALID_TOKEN,
                              RESPONSE_400_UNEXPECTED_PARAMETERS,
                              RESPONSE_403_USER_ALREADY_ADMIN,
+                             RESPONSE_403_ADMINS_PERMISSIONS_UNCONFIRMED,
                              RESPONSE_404_ADMINS_GROUP_INACCESSIBLE)
 from utils.send_email import send_email
 from .manage_apps import ADMIN_MANAGEMENT_APPS
@@ -83,3 +85,17 @@ class AdminViewSet(viewsets.ViewSet):
             return RESPONSE_400_UNEXPECTED_PARAMETERS
 
         return Response(ADMIN_MANAGEMENT_APPS, status=200)
+
+    @staticmethod
+    @action(methods=['get'],
+            detail=False,
+            permission_classes=[IsAuthenticated])
+    def permissions(request):
+        """Check does the requested user has administration premissions."""
+
+        admins_group = Group.objects.get(name='admins')
+        try:
+            admins_group.user_set.get(email=request.user.email)
+            return RESPONSE_200_ADMINS_PERMISSIONS_COMFIRMED
+        except CustomUser.DoesNotExist:
+            return RESPONSE_403_ADMINS_PERMISSIONS_UNCONFIRMED

--- a/bibliotekanarynku9_api/utils/responses.py
+++ b/bibliotekanarynku9_api/utils/responses.py
@@ -26,6 +26,11 @@ RESPONSE_200_ADMINS_JOINED = Response(
     status=status.HTTP_200_OK
 )
 
+RESPONSE_200_ADMINS_PERMISSIONS_COMFIRMED = Response(
+    'User is a member of Admins group.',
+    status=status.HTTP_200_OK
+)
+
 RESPONSE_200_DELETED = Response(
     'Object successfully deleted.',
     status=status.HTTP_200_OK
@@ -88,6 +93,11 @@ RESPONSE_400_DB_INTEGRATION_FAILURE = Response(
 
 RESPONSE_403_USER_ALREADY_ADMIN = Response(
     'User already is in Admins group.',
+    status=status.HTTP_403_FORBIDDEN
+)
+
+RESPONSE_403_ADMINS_PERMISSIONS_UNCONFIRMED = Response(
+    'User is not a member of Admins group.',
     status=status.HTTP_403_FORBIDDEN
 )
 


### PR DESCRIPTION
Added the `permissions` admin endpoint to the api.
Added the `RESPONSE_200_ADMINS_PERMISSIONS_COMFIRMED` and
`RESPONSE_403_ADMINS_PERMISSIONS_UNCONFIRMED` responses to the responses.py helper file.
Updated the `AdminMessage` component to handle the empty links props.
Added the `requestPermissions` service to check is user admin.
Refactored `Admin` container to render the app bar all time.
Added the permissions option in the `AdminAccessMessage` component.