### PR TITLE
Announcement Organizer Admin field

### DIFF
--- a/bibliotekanarynku9_administration_panel/src/components/AdminOrganizerField/AdminOrganizerField.js
+++ b/bibliotekanarynku9_administration_panel/src/components/AdminOrganizerField/AdminOrganizerField.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+import Input from '@material-ui/core/Input';
+import InputLabel from '@material-ui/core/InputLabel';
+import FormControl from '@material-ui/core/FormControl';
+
+const style = {
+    margin: '10px 0'
+};
+
+export default class AdminOrganizerField extends React.Component {
+
+    handleChange = event => {
+        this.props.onOrganizerChange(event.target.value);
+    }
+
+    renderEditField = () => {
+        return (
+            <div>
+                <FormControl>
+                    <InputLabel>{this.props.label}</InputLabel>
+                    <Input
+                        value={this.props.organizer}
+                        onChange={this.handleChange}
+                        error={this.props.isError}
+                    />
+                </FormControl>
+            </div>
+        );
+    }
+
+    renderLookUpField = () => {
+        return (
+            this.props.organizer &&
+            <div>
+                <Typography component='p'>
+                    Organizer: {this.props.organizer}
+                </Typography>
+            </div>
+        );
+    }
+
+    render() {
+        return (
+            <div style={style}>
+                {this.props.isEdit ? this.renderEditField() : this.renderLookUpField()}
+            </div>
+        );
+    }
+}

--- a/bibliotekanarynku9_administration_panel/src/components/AdminOrganizerField/index.js
+++ b/bibliotekanarynku9_administration_panel/src/components/AdminOrganizerField/index.js
@@ -1,0 +1,1 @@
+export {default} from './AdminOrganizerField';

--- a/bibliotekanarynku9_administration_panel/src/containers/Announcement/AdminAddAnnouncementTranslationForm.js
+++ b/bibliotekanarynku9_administration_panel/src/containers/Announcement/AdminAddAnnouncementTranslationForm.js
@@ -5,6 +5,7 @@ import AdminButton from '../../components/AdminButton';
 import AdminLanguageSelect from '../../components/AdminLanguageSelect';
 import AdminTitleField from '../../components/AdminTitleField';
 import AdminDescriptionField from '../../components/AdminDescriptionField';
+import AdminOrganizerField from '../../components/AdminOrganizerField/AdminOrganizerField';
 import {getUpdatedState} from '../../helpers';
 import {postAnnouncementTranslationService } from './adminAnnouncementService';
 
@@ -23,6 +24,7 @@ class AdminAddAnnouncementTranslationForm extends React.Component {
         this.state = {
             title: '',
             description: '',
+            organizer: '',
             language: 'uk',
             isError: false
         };
@@ -40,6 +42,10 @@ class AdminAddAnnouncementTranslationForm extends React.Component {
         this.setState(getUpdatedState({description: newDescription}, this.state));
     }
 
+    handleOrganizerChange = newOrganizer => {
+        this.setState(getUpdatedState({organizer: newOrganizer}, this.state));
+    }
+
     handleLanguageChange = newLanguage => {
         this.setState(getUpdatedState({language: newLanguage}, this.state));
     }
@@ -49,11 +55,13 @@ class AdminAddAnnouncementTranslationForm extends React.Component {
             this.props.announcementId,
             this.state.title,
             this.state.description,
+            this.state.organizer,
             this.state.language
         ).then(() => {
             this.setState(getUpdatedState({
                 title: '',
                 description: '',
+                organizer: '',
                 language: 'uk',
                 isError: false
             }, this.state));
@@ -82,6 +90,13 @@ class AdminAddAnnouncementTranslationForm extends React.Component {
                         description={this.state.description}
                         label='description'
                         onDescriptionChange={this.handleDescriptionChange}
+                        isEdit={true}
+                        isError={this.state.isError}
+                    />
+                    <AdminOrganizerField
+                        organizer={this.state.organizer}
+                        label='organizer'
+                        onOrganizerChange={this.handleOrganizerChange}
                         isEdit={true}
                         isError={this.state.isError}
                     />

--- a/bibliotekanarynku9_administration_panel/src/containers/Announcement/AdminAnnouncementItem.js
+++ b/bibliotekanarynku9_administration_panel/src/containers/Announcement/AdminAnnouncementItem.js
@@ -144,10 +144,13 @@ class AdminAnnouncementItem extends React.Component {
                                             id={translation.id}
                                             title={translation.title}
                                             description={translation.description}
+                                            organizer={translation.organizer}
                                             links={translation.links}
                                             isEdit={this.state.isEdit}
+                                            onUpdateTranslationSuccess={this.getAnnouncement}
                                             onRemoveTranslationSuccess={this.getAnnouncement}
                                             onAddTranslationLinkSuccess={this.getAnnouncement}
+                                            onUpdateTranslationLinkSuccess={this.getAnnouncement}
                                             onRemoveTranslationLinkSuccess={this.getAnnouncement}
                                         />
                                     );

--- a/bibliotekanarynku9_administration_panel/src/containers/Announcement/AdminAnnouncementItemTranslation.js
+++ b/bibliotekanarynku9_administration_panel/src/containers/Announcement/AdminAnnouncementItemTranslation.js
@@ -3,10 +3,11 @@ import Divider from '@material-ui/core/Divider';
 import AdminButton from '../../components/AdminButton';
 import AdminTitleField from '../../components/AdminTitleField';
 import AdminDescriptionField from '../../components/AdminDescriptionField';
-import {getUpdatedState} from '../../helpers';
-import {putAnnouncementTranslationService, deleteAnnouncementTranslationService, postAnnouncementTranslationLinkService, putAnnouncementTranslationLinkService, deleteAnnouncementTranslationLinkService} from './adminAnnouncementService';
+import AdminOrganizerField from '../../components/AdminOrganizerField/AdminOrganizerField';
 import AdminAnnouncementTranslationLinksList from './AdminAnnouncementTranslationLinksList';
 import AdminAddLinkForm from '../../components/AdminAddLinkForm/AdminAddLinkForm';
+import {putAnnouncementTranslationService, deleteAnnouncementTranslationService, postAnnouncementTranslationLinkService, putAnnouncementTranslationLinkService, deleteAnnouncementTranslationLinkService} from './adminAnnouncementService';
+import {getUpdatedState} from '../../helpers';
 
 const buttonsWrapperSty = {
     display: 'flex'
@@ -26,6 +27,8 @@ class AdminAnnouncementItemTranslation extends React.Component {
             updatedTitle: props.title,
             description: props.description,
             updatedDescription: props.description,
+            organizer: props.organizer,
+            updatedOrganizer: props.organizer,
             isError: false,
             isAddLinkFormError: false,
             isUpdateLinkError: false
@@ -38,13 +41,16 @@ class AdminAnnouncementItemTranslation extends React.Component {
             updatedTitle: nextProps.title,
             description: nextProps.description,
             updatedDescription: nextProps.description,
+            organizer: nextProps.organizer,
+            updatedOrganizer: nextProps.organizer
         }, this.state));
     }
 
     haveFieldsChanged = () => {
         return !(
             this.state.title === this.state.updatedTitle &&
-            this.state.description === this.state.updatedDescription
+            this.state.description === this.state.updatedDescription &&
+            this.state.organizer === this.state.updatedOrganizer
         );
     }
 
@@ -60,18 +66,27 @@ class AdminAnnouncementItemTranslation extends React.Component {
         }, this.state));
     }
 
+    handleOrganizerChange = newOrganizer => {
+        this.setState(getUpdatedState({
+            updatedOrganizer: newOrganizer,
+        }, this.state));
+    }
+
     handleSaveTranslationClick = () => {
         putAnnouncementTranslationService(
             this.props.announcementId,
             this.props.id,
             this.state.updatedTitle,
-            this.state.updatedDescription
+            this.state.updatedDescription,
+            this.state.updatedOrganizer
         ).then(() => {
             this.setState(getUpdatedState({
                 title: this.state.updatedTitle,
                 description: this.state.updatedDescription,
+                organizer: this.state.updatedOrganizer,
                 isError: false
             }, this.state));
+            this.props.onUpdateTranslationSuccess();
         }).catch(() => {
             this.setState(getUpdatedState({isError: true}, this.state));
         });
@@ -115,6 +130,7 @@ class AdminAnnouncementItemTranslation extends React.Component {
             this.setState(getUpdatedState({
                 isUpdateLinkError: false
             }, this.state));
+            this.props.onUpdateTranslationLinkSuccess();
         }).catch(() => {
             this.setState(getUpdatedState({
                 isUpdateLinkError: true
@@ -147,6 +163,13 @@ class AdminAnnouncementItemTranslation extends React.Component {
                     description={this.state.updatedDescription}
                     label='Description'
                     onDescriptionChange={this.handleDescriptionChange}
+                    isEdit={this.props.isEdit}
+                    isError={this.state.isError}
+                />
+                <AdminOrganizerField
+                    organizer={this.state.updatedOrganizer}
+                    label='organizer'
+                    onOrganizerChange={this.handleOrganizerChange}
                     isEdit={this.props.isEdit}
                     isError={this.state.isError}
                 />

--- a/bibliotekanarynku9_administration_panel/src/containers/Announcement/adminAnnouncementService.js
+++ b/bibliotekanarynku9_administration_panel/src/containers/Announcement/adminAnnouncementService.js
@@ -24,13 +24,15 @@ export const postAnnouncementService = (avatar, startAt) => {
     });
 };
 
-export const postAnnouncementTranslationService = (announcementId, title, description, language) => {
+export const postAnnouncementTranslationService = (announcementId, title, description, organizer, language) => {
     const url = `${apiPath}${announcementPath}${announcementId}/translation/`;
-    return axios.post(url, {
+    const data = {
         title: title,
         description: description,
         language: LANGUAGE_CODES[language]
-    }, {
+    };
+    if (organizer) data.organizer = organizer;
+    return axios.post(url, data, {
         headers: {
             'X-CSRFToken': getCSRFToken()
         }
@@ -60,11 +62,12 @@ export const putAnnouncementService = (announcementId, avatar, startAt) => {
     });
 };
 
-export const putAnnouncementTranslationService = (announcementId, translationId, title, description) => {
+export const putAnnouncementTranslationService = (announcementId, translationId, title, description, organizer) => {
     const url = `${apiPath}${announcementPath}${announcementId}/translation/${translationId}/`;
     return axios.put(url, {
         title: title,
-        description: description
+        description: description,
+        organizer: organizer
     }, {
         headers: {
             'X-CSRFToken': getCSRFToken()


### PR DESCRIPTION
Added the organizer field to the `AdminAddAnnouncementTranslationForm` component.
Fixed the outdated state in the `AnnouncementTransationItem` component when the put
request was produced.
Added the organizer logic to the `AdminAnnouncementItemTranslation` component.
Updated the post and put translation services.
Created the `AdminOrganizerField` component.