### PR TITLE
User session clean-up

### DIFF
--- a/bibliotekanarynku9_api/bibliotekanarynku9_api/settings.py
+++ b/bibliotekanarynku9_api/bibliotekanarynku9_api/settings.py
@@ -172,6 +172,13 @@ LOGGING = {
 }
 
 
+# TTL settings for the user session id and CSRF token
+
+SESSION_COOKIE_AGE = 3 * 60 * 60 # 3 hours
+
+CSRF_COOKIE_AGE = SESSION_COOKIE_AGE
+
+
 # Email sender settings
 
 EMAIL_USE_TLS = True


### PR DESCRIPTION
Decreased time of user session to 3 hours.
Used the one session variable for CSRF and session id tokens TTL.
Refactor authentication view for more readability.