### PR TITLE
Google My Business Service API Call

### DIFF
--- a/bibliotekanarynku9_api/googlemybusiness/views.py
+++ b/bibliotekanarynku9_api/googlemybusiness/views.py
@@ -10,8 +10,6 @@ from authentication.permissions import IsAdminsMember
 from googlemybusiness.models import GoogleMyBusinessAccount
 from googlemybusiness.provider import GOOGLE_MY_BUSINESS_OAUTH_PROVIDER
 from googlemybusiness.service import GOOGLE_MY_BUSINESS_API_SERVICE
-from googleoauth.models import GoogleOAuthSession
-from googleoauth.utils import GoogleServices
 from utils.responses import (
     RESPONSE_400_NO_OAUTH_CODE_PROVIDED,
     RESPONSE_400_ACCESS_TOKEN_GENERATION_FAILURE,
@@ -20,8 +18,6 @@ from utils.responses import (
     RESPONSE_201_GENERATED_ACCESS_TOKEN,
     RESPONSE_404_GOOGLE_BUSINESS_ACCOUNT_NOT_FOUND,
     RESPONSE_400_GOOGLE_BUSINESS_ACCOUNT_SAVING_FAILURE,
-    RESPONSE_400_REFRESH_TOKEN_FAILURE,
-    RESPONSE_200_ACCESS_TOKEN_REFRESHED,
 )
 
 
@@ -86,23 +82,3 @@ class GoogleMyBusinessViewSet(viewsets.ViewSet):
         if GOOGLE_MY_BUSINESS_OAUTH_PROVIDER.get_access_token(request.user):
             return RESPONSE_200_ACCESS_TOKEN_EXISTS
         return RESPONSE_404_ACCESS_TOKEN_NOT_FOUND
-
-    # TODO: Temporary endpoint for manual token refresh
-    @staticmethod
-    @action(methods=["get"], detail=False, permission_classes=[IsAdminsMember])
-    def refresh_token(request):
-        """
-        Method that refreshes token for the current session user.
-        """
-
-        session = GoogleOAuthSession.get_service_session_by_user(
-            GoogleServices.MY_BUSINESS.value, request.user
-        )
-        if not session:
-            return RESPONSE_404_ACCESS_TOKEN_NOT_FOUND
-        is_refreshed = GOOGLE_MY_BUSINESS_OAUTH_PROVIDER.refresh_token(
-            request.user, session.refresh_token
-        )
-        if not is_refreshed:
-            return RESPONSE_400_REFRESH_TOKEN_FAILURE
-        return RESPONSE_200_ACCESS_TOKEN_REFRESHED

--- a/bibliotekanarynku9_api/googleoauth/googleoauth.py
+++ b/bibliotekanarynku9_api/googleoauth/googleoauth.py
@@ -87,6 +87,15 @@ class GoogleOAuthProvider:
         """
         return GoogleOAuthSession.get_service_access_token_by_user(self.service, user)
 
+    def get_refresh_token(self, user):
+        """
+        Method that retrieves previous generated refresh token from database.
+        It retrieves refresh token for the certain user and service.
+        :param user: CustomUser instance that represents the session user.
+        :return: str that represents refresh token.
+        """
+        return GoogleOAuthSession.get_service_refresh_token_by_user(self.service, user)
+
     def refresh_token(self, user, refresh_token):
         """
         Method that refreshes the outdated access token for the certain user.

--- a/bibliotekanarynku9_api/googleoauth/models.py
+++ b/bibliotekanarynku9_api/googleoauth/models.py
@@ -72,6 +72,23 @@ class GoogleOAuthSession(AbstractModel):
         return ""
 
     @classmethod
+    def get_service_refresh_token_by_user(cls, service, user):
+        """
+        Method that returns refresh token for the accepted service and user.
+        :param service: int that represents the one of the Google Services.
+        :param user: CustomUser instance that represent current session user.
+        :return: str that represents user's refresh token.
+        """
+        oauth_session = cls.get_service_session_by_user(service=service, user=user)
+        if oauth_session:
+            return oauth_session.refresh_token
+        LOGGER.error(
+            f"Cannot retrieve the access token for service: {service} and user: {user}. "
+            f"There is no {cls.__name__} instance."
+        )
+        return ""
+
+    @classmethod
     def get_access_token_expire_time(cls, service, user):
         """
         Method that returns the time when access token will become invalid.

--- a/bibliotekanarynku9_api/utils/responses.py
+++ b/bibliotekanarynku9_api/utils/responses.py
@@ -30,10 +30,6 @@ RESPONSE_200_ACCESS_TOKEN_EXISTS = Response(
     "Access token is already generated for the user.", status=status.HTTP_200_OK
 )
 
-RESPONSE_200_ACCESS_TOKEN_REFRESHED = Response(
-    "Access token is sucessfully refreshed.", status=status.HTTP_200_OK
-)
-
 RESPONSE_201_GENERATED_ACCESS_TOKEN = Response(
     "Access token successfully generated for the user. Please go to the main site page.",
     status=status.HTTP_201_CREATED,
@@ -91,10 +87,6 @@ RESPONSE_400_GOOGLE_BUSINESS_ACCOUNT_SAVING_FAILURE = Response(
 RESPONSE_400_GOOGLE_BUSINESS_ANNOUNCEMENT_SYNCHRONIZATION_FAILURE = Response(
     "Cannot create locationPost entity for Announcement at Google My Business service.",
     status=status.HTTP_400_BAD_REQUEST,
-)
-
-RESPONSE_400_REFRESH_TOKEN_FAILURE = Response(
-    "Cannot refresh token for the user.", status=status.HTTP_400_BAD_REQUEST,
 )
 
 RESPONSE_403_USER_ALREADY_ADMIN = Response(


### PR DESCRIPTION
Created the api_call decorator that before each API call checks
is access token expired and if so refreshes it.
Remove refresh_toke view.
Added get_refresh token methods to the GoogleOAuth session model.